### PR TITLE
feat: add entrypoint

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,0 +1,5 @@
+// Unopinionated extensable tslint configuration
+// Loads rules for extending packages, but does not enable any
+module.exports = {
+  rulesDirectory: "./",
+};

--- a/index.js
+++ b/index.js
@@ -1,5 +1,5 @@
-// Unopinionated extensable tslint configuration
+// Unopinionated extensible tslint configuration
 // Loads rules for extending packages, but does not enable any
 module.exports = {
-  rulesDirectory: "./",
+  rulesDirectory: './',
 };

--- a/package.json
+++ b/package.json
@@ -12,6 +12,7 @@
   ],
   "author": "Heather Roberts",
   "license": "ISC",
+  "main": "index.js",
   "repository": {
     "type": "git",
     "url": "git+https://github.com/chinchiheather/tslint-lines-between-class-members.git"


### PR DESCRIPTION
Thanks for these rules!

I'm trying to load the rules via `require.resolve` because I'm building a shared lint.json for my company (see for example the [ionic tslint rules](https://github.com/ionic-team/tslint-ionic-rules/blob/master/tslint.js)). The moment I do `require.resolve('tslint-lines-between-class-members')` I get a problem because Node complains about the package not being a module. Needless to say, this is because it finds no exported module to resolve.

This PR adds a pretty simple entrypoint (`index.js`) for Node to be able to resolve it correctly. This same entrypoint is used in [codelyzer](https://github.com/mgechev/codelyzer/blob/master/index.js), [tslint-eslint-code](https://github.com/buzinas/tslint-eslint-rules/blob/master/index.js), and many more popular rule sets.