### PR TITLE
Handling Allman brace style for the first method case

### DIFF
--- a/linesBetweenClassMembersRule.js
+++ b/linesBetweenClassMembersRule.js
@@ -12,7 +12,7 @@ var __extends = (this && this.__extends) || (function () {
 Object.defineProperty(exports, "__esModule", { value: true });
 var Lint = require("tslint");
 var ts = require("typescript");
-var Rule = /** @class */ (function (_super) {
+var Rule = (function (_super) {
     __extends(Rule, _super);
     function Rule() {
         return _super !== null && _super.apply(this, arguments) || this;
@@ -20,11 +20,11 @@ var Rule = /** @class */ (function (_super) {
     Rule.prototype.apply = function (sourceFile) {
         return this.applyWithWalker(new LinesBetweenClassMembersWalker(sourceFile, this.getOptions()));
     };
-    Rule.FAILURE_STRING = 'must have blank line between class methods';
     return Rule;
 }(Lint.Rules.AbstractRule));
+Rule.FAILURE_STRING = 'must have blank line between class methods';
 exports.Rule = Rule;
-var LinesBetweenClassMembersWalker = /** @class */ (function (_super) {
+var LinesBetweenClassMembersWalker = (function (_super) {
     __extends(LinesBetweenClassMembersWalker, _super);
     function LinesBetweenClassMembersWalker() {
         return _super !== null && _super.apply(this, arguments) || this;
@@ -42,8 +42,8 @@ var LinesBetweenClassMembersWalker = /** @class */ (function (_super) {
     LinesBetweenClassMembersWalker.prototype.validate = function (node) {
         var isPrevLineBlank = this.isPreviousLineBlank(node, this.getSourceFile());
         var isPrevLineClassDec = this.isPreviousLineClassDec(node, this.getSourceFile());
-        var isPrevLineOpenningBrace = this.isPrevLineOpenningBrace(node, this.getSourceFile());
-        if (!isPrevLineBlank && !isPrevLineClassDec && !isPrevLineOpenningBrace) {
+        var isPrevLineOpeningBrace = this.isPrevLineOpeningBrace(node, this.getSourceFile());
+        if (!isPrevLineBlank && !isPrevLineClassDec && !isPrevLineOpeningBrace) {
             this.onRuleLintFail(node);
         }
     };
@@ -65,9 +65,9 @@ var LinesBetweenClassMembersWalker = /** @class */ (function (_super) {
     };
     /**
      * Tests whether the previous line is the openning brace
-     * We do not want to enforce a newline after openning brace for the class declaration
+     * We do not want to enforce a newline after opening brace for the class declaration
      */
-    LinesBetweenClassMembersWalker.prototype.isPrevLineOpenningBrace = function (node, sourceFile) {
+    LinesBetweenClassMembersWalker.prototype.isPrevLineOpeningBrace = function (node, sourceFile) {
         var prevLine = this.getPrevLineText(node, sourceFile);
         return prevLine.trim() === '{';
     };

--- a/linesBetweenClassMembersRule.js
+++ b/linesBetweenClassMembersRule.js
@@ -12,7 +12,7 @@ var __extends = (this && this.__extends) || (function () {
 Object.defineProperty(exports, "__esModule", { value: true });
 var Lint = require("tslint");
 var ts = require("typescript");
-var Rule = (function (_super) {
+var Rule = /** @class */ (function (_super) {
     __extends(Rule, _super);
     function Rule() {
         return _super !== null && _super.apply(this, arguments) || this;
@@ -20,11 +20,11 @@ var Rule = (function (_super) {
     Rule.prototype.apply = function (sourceFile) {
         return this.applyWithWalker(new LinesBetweenClassMembersWalker(sourceFile, this.getOptions()));
     };
+    Rule.FAILURE_STRING = 'must have blank line between class methods';
     return Rule;
 }(Lint.Rules.AbstractRule));
-Rule.FAILURE_STRING = 'must have blank line between class methods';
 exports.Rule = Rule;
-var LinesBetweenClassMembersWalker = (function (_super) {
+var LinesBetweenClassMembersWalker = /** @class */ (function (_super) {
     __extends(LinesBetweenClassMembersWalker, _super);
     function LinesBetweenClassMembersWalker() {
         return _super !== null && _super.apply(this, arguments) || this;
@@ -42,7 +42,8 @@ var LinesBetweenClassMembersWalker = (function (_super) {
     LinesBetweenClassMembersWalker.prototype.validate = function (node) {
         var isPrevLineBlank = this.isPreviousLineBlank(node, this.getSourceFile());
         var isPrevLineClassDec = this.isPreviousLineClassDec(node, this.getSourceFile());
-        if (!isPrevLineBlank && !isPrevLineClassDec) {
+        var isPrevLineOpenningBrace = this.isPrevLineOpenningBrace(node, this.getSourceFile());
+        if (!isPrevLineBlank && !isPrevLineClassDec && !isPrevLineOpenningBrace) {
             this.onRuleLintFail(node);
         }
     };
@@ -61,6 +62,14 @@ var LinesBetweenClassMembersWalker = (function (_super) {
     LinesBetweenClassMembersWalker.prototype.isPreviousLineClassDec = function (node, sourceFile) {
         var prevLine = this.getPrevLineText(node, sourceFile);
         return /\bclass\b\s+[A-Za-z0-9]+/.test(prevLine);
+    };
+    /**
+     * Tests whether the previous line is the openning brace
+     * We do not want to enforce a newline after openning brace for the class declaration
+     */
+    LinesBetweenClassMembersWalker.prototype.isPrevLineOpenningBrace = function (node, sourceFile) {
+        var prevLine = this.getPrevLineText(node, sourceFile);
+        return prevLine.trim() === '{';
     };
     /**
      * Gets the text content of the line above the method

--- a/src/linesBetweenClassMembersRule.spec.ts
+++ b/src/linesBetweenClassMembersRule.spec.ts
@@ -51,6 +51,11 @@ test('passes if first method in class and no new line before it', (t: AssertCont
   t.is(results.errorCount, 0);
 });
 
+test('passes if first method in class and opening brace before it', (t: AssertContext) => {
+  const results = TestHelpers.lint('passes/firstMethodNewLineWithAllmanBraceStyle.ts');
+  t.is(results.errorCount, 0);
+});
+
 test('passes if new line and method comment between class methods', (t: AssertContext) => {
   const results = TestHelpers.lint('passes/newLineAndMethodComment.ts');
   t.is(results.errorCount, 0);

--- a/src/linesBetweenClassMembersRule.ts
+++ b/src/linesBetweenClassMembersRule.ts
@@ -30,7 +30,8 @@ class LinesBetweenClassMembersWalker extends Lint.RuleWalker {
   private validate(node: ts.FunctionLikeDeclaration) {
     const isPrevLineBlank = this.isPreviousLineBlank(node, this.getSourceFile());
     const isPrevLineClassDec = this.isPreviousLineClassDec(node, this.getSourceFile());
-    if (!isPrevLineBlank && !isPrevLineClassDec) {
+    const isPrevLineOpenningBrace = this.isPrevLineOpenningBrace(node, this.getSourceFile());
+    if (!isPrevLineBlank && !isPrevLineClassDec && !isPrevLineOpenningBrace) {
       this.onRuleLintFail(node);
     }
   }
@@ -51,6 +52,15 @@ class LinesBetweenClassMembersWalker extends Lint.RuleWalker {
   private isPreviousLineClassDec(node: ts.FunctionLikeDeclaration, sourceFile: ts.SourceFile): boolean {
     const prevLine = this.getPrevLineText(node, sourceFile);
     return /\bclass\b\s+[A-Za-z0-9]+/.test(prevLine);
+  }
+
+  /**
+   * Tests whether the previous line is the openning brace
+   * We do not want to enforce a newline after openning brace for the class declaration
+   */
+  private isPrevLineOpenningBrace(node: ts.FunctionLikeDeclaration, sourceFile: ts.SourceFile): boolean {
+    const prevLine = this.getPrevLineText(node, sourceFile);
+    return prevLine.trim() === '{';
   }
 
   /**

--- a/src/linesBetweenClassMembersRule.ts
+++ b/src/linesBetweenClassMembersRule.ts
@@ -30,8 +30,8 @@ class LinesBetweenClassMembersWalker extends Lint.RuleWalker {
   private validate(node: ts.FunctionLikeDeclaration) {
     const isPrevLineBlank = this.isPreviousLineBlank(node, this.getSourceFile());
     const isPrevLineClassDec = this.isPreviousLineClassDec(node, this.getSourceFile());
-    const isPrevLineOpenningBrace = this.isPrevLineOpenningBrace(node, this.getSourceFile());
-    if (!isPrevLineBlank && !isPrevLineClassDec && !isPrevLineOpenningBrace) {
+    const isPrevLineOpeningBrace = this.isPrevLineOpeningBrace(node, this.getSourceFile());
+    if (!isPrevLineBlank && !isPrevLineClassDec && !isPrevLineOpeningBrace) {
       this.onRuleLintFail(node);
     }
   }
@@ -56,9 +56,9 @@ class LinesBetweenClassMembersWalker extends Lint.RuleWalker {
 
   /**
    * Tests whether the previous line is the openning brace
-   * We do not want to enforce a newline after openning brace for the class declaration
+   * We do not want to enforce a newline after opening brace for the class declaration
    */
-  private isPrevLineOpenningBrace(node: ts.FunctionLikeDeclaration, sourceFile: ts.SourceFile): boolean {
+  private isPrevLineOpeningBrace(node: ts.FunctionLikeDeclaration, sourceFile: ts.SourceFile): boolean {
     const prevLine = this.getPrevLineText(node, sourceFile);
     return prevLine.trim() === '{';
   }

--- a/src/linesBetweenClassMembersRule.ts
+++ b/src/linesBetweenClassMembersRule.ts
@@ -55,7 +55,7 @@ class LinesBetweenClassMembersWalker extends Lint.RuleWalker {
   }
 
   /**
-   * Tests whether the previous line is the openning brace
+   * Tests whether the previous line is the opening brace
    * We do not want to enforce a newline after opening brace for the class declaration
    */
   private isPrevLineOpeningBrace(node: ts.FunctionLikeDeclaration, sourceFile: ts.SourceFile): boolean {

--- a/test/fixtures/passes/firstMethodNewLineWithAllmanBraceStyle.ts
+++ b/test/fixtures/passes/firstMethodNewLineWithAllmanBraceStyle.ts
@@ -1,0 +1,6 @@
+class FirstMethodNoNewLineWithAllmanBraceStlye
+{
+  constructor() {}
+
+  method() {}
+}

--- a/test/fixtures/passes/firstMethodNoNewLine.ts
+++ b/test/fixtures/passes/firstMethodNoNewLine.ts
@@ -3,3 +3,11 @@ class FirstMethodNoNewLine {
 
   method() {}
 }
+
+class FirstMethodNoNewLineWithAllmanBraceStlye
+{
+  constructor() {}
+
+  method() {}
+}
+

--- a/test/fixtures/passes/firstMethodNoNewLine.ts
+++ b/test/fixtures/passes/firstMethodNoNewLine.ts
@@ -3,11 +3,3 @@ class FirstMethodNoNewLine {
 
   method() {}
 }
-
-class FirstMethodNoNewLineWithAllmanBraceStlye
-{
-  constructor() {}
-
-  method() {}
-}
-


### PR DESCRIPTION
@chinchiheather This PR tries to fix the following case:

```ts
class FirstMethodNoNewLineWithAllmanBraceStlye
{
  constructor() {}

  method() {}
}
```

After styling this code piece becomes:

```ts
class FirstMethodNoNewLineWithAllmanBraceStlye
{
  
  constructor() {}

  method() {}
}
```

Which has the unwanted newline before the constructor.