### PR TITLE
Only apply rule to methods within a class declaration

### DIFF
--- a/linesBetweenClassMembersRule.js
+++ b/linesBetweenClassMembersRule.js
@@ -44,7 +44,8 @@ var LinesBetweenClassMembersWalker = (function (_super) {
         var arePrevLinesBlank = this.arePreviousLinesBlank(node, this.getSourceFile());
         var isPrevLineClassDec = this.isPreviousLineClassDec(node, this.getSourceFile());
         var isPrevLineOpeningBrace = this.isPrevLineOpeningBrace(node, this.getSourceFile());
-        if (!arePrevLinesBlank && !isPrevLineClassDec && !isPrevLineOpeningBrace) {
+        var isClassMethod = this.isClassMethod(node);
+        if (!arePrevLinesBlank && !isPrevLineClassDec && !isPrevLineOpeningBrace && isClassMethod) {
             this.onRuleLintFail(node);
         }
     };
@@ -109,6 +110,13 @@ var LinesBetweenClassMembersWalker = (function (_super) {
     LinesBetweenClassMembersWalker.prototype.isPrevLineOpeningBrace = function (node, sourceFile) {
         var prevLine = this.getPrevLinesText(node, sourceFile);
         return prevLine.trim() === '{';
+    };
+    /**
+     * Tests whether method is within a class (as opposed to within an object literal)
+     */
+    LinesBetweenClassMembersWalker.prototype.isClassMethod = function (node) {
+        var parentType = node.parent && node.parent.kind;
+        return parentType === ts.SyntaxKind.ClassDeclaration;
     };
     /**
      * Gets the text content of a line above the method

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "tslint-lines-between-class-members",
-  "version": "1.3.0",
+  "version": "1.3.1",
   "description": "Custom rule for TSLint to enforce blank lines between class methods - achieves a similar thing to lines-between-class-members in ESLint",
   "scripts": {
     "compile": "tsc",

--- a/src/linesBetweenClassMembersRule.spec.ts
+++ b/src/linesBetweenClassMembersRule.spec.ts
@@ -211,3 +211,23 @@ test('fails when invalid value passed for num lines option', (t: AssertContext) 
   t.is(results.errorCount, 2);
   checkInvalidConfigFailMessage(t, results);
 });
+
+test('ignores default exported object', (t: AssertContext) => {
+  const results = TestHelpers.lint('passes/exportDefault.ts');
+  t.is(results.errorCount, 0);
+});
+
+test('ignores default exported object with multiple methods', (t: AssertContext) => {
+  const results = TestHelpers.lint('passes/exportDefaultMultipleMethods.ts');
+  t.is(results.errorCount, 0);
+});
+
+test('ignores exported object', (t: AssertContext) => {
+  const results = TestHelpers.lint('passes/export.ts');
+  t.is(results.errorCount, 0);
+});
+
+test('ignores exported object with multiple methods', (t: AssertContext) => {
+  const results = TestHelpers.lint('passes/exportMultipleMethods.ts');
+  t.is(results.errorCount, 0);
+});

--- a/src/linesBetweenClassMembersRule.ts
+++ b/src/linesBetweenClassMembersRule.ts
@@ -35,7 +35,8 @@ class LinesBetweenClassMembersWalker extends Lint.RuleWalker {
     const arePrevLinesBlank = this.arePreviousLinesBlank(node, this.getSourceFile());
     const isPrevLineClassDec = this.isPreviousLineClassDec(node, this.getSourceFile());
     const isPrevLineOpeningBrace = this.isPrevLineOpeningBrace(node, this.getSourceFile());
-    if (!arePrevLinesBlank && !isPrevLineClassDec && !isPrevLineOpeningBrace) {
+    const isClassMethod = this.isClassMethod(node);
+    if (!arePrevLinesBlank && !isPrevLineClassDec && !isPrevLineOpeningBrace && isClassMethod) {
       this.onRuleLintFail(node);
     }
   }
@@ -106,6 +107,14 @@ class LinesBetweenClassMembersWalker extends Lint.RuleWalker {
   private isPrevLineOpeningBrace(node: ts.FunctionLikeDeclaration, sourceFile: ts.SourceFile): boolean {
     const prevLine = this.getPrevLinesText(node, sourceFile);
     return prevLine.trim() === '{';
+  }
+
+  /**
+   * Tests whether method is within a class (as opposed to within an object literal)
+   */
+  private isClassMethod(node: ts.FunctionLikeDeclaration): boolean {
+    const parentType = node.parent && node.parent.kind;
+    return parentType === ts.SyntaxKind.ClassDeclaration;
   }
 
   /**

--- a/test/fixtures/passes/export.ts
+++ b/test/fixtures/passes/export.ts
@@ -1,0 +1,5 @@
+function myFunc() {}
+
+export {
+  myFunc
+};

--- a/test/fixtures/passes/exportDefault.ts
+++ b/test/fixtures/passes/exportDefault.ts
@@ -1,0 +1,3 @@
+export default {
+  method() {}
+};

--- a/test/fixtures/passes/exportDefaultMultipleMethods.ts
+++ b/test/fixtures/passes/exportDefaultMultipleMethods.ts
@@ -1,0 +1,5 @@
+
+export default {
+  method() {},
+  method2() {}
+};

--- a/test/fixtures/passes/exportDefaultMultipleMethods.ts
+++ b/test/fixtures/passes/exportDefaultMultipleMethods.ts
@@ -1,4 +1,3 @@
-
 export default {
   method() {},
   method2() {}

--- a/test/fixtures/passes/exportMultipleMethods.ts
+++ b/test/fixtures/passes/exportMultipleMethods.ts
@@ -1,0 +1,8 @@
+function myMethod() {}
+
+function myMethod2() {}
+
+export {
+  myMethod,
+  myMethod2
+};


### PR DESCRIPTION
Fixes #10 

Now we check the type of the parent node and only apply rule if parent is a class declaration