### PR TITLE
fix closing generic with open brace same line caused by Prettier

### DIFF
--- a/linesBetweenClassMembersRule.js
+++ b/linesBetweenClassMembersRule.js
@@ -108,8 +108,8 @@ var LinesBetweenClassMembersWalker = (function (_super) {
      * We do not want to enforce a newline after opening brace for the class declaration
      */
     LinesBetweenClassMembersWalker.prototype.isPrevLineOpeningBrace = function (node, sourceFile) {
-        var prevLine = this.getPrevLinesText(node, sourceFile);
-        return prevLine.trim() === '{';
+        var prevLine = this.getPrevLinesText(node, sourceFile).trim();
+        return prevLine === '{' || prevLine === '> {';
     };
     /**
      * Tests whether method is within a class (as opposed to within an object literal)

--- a/src/linesBetweenClassMembersRule.spec.ts
+++ b/src/linesBetweenClassMembersRule.spec.ts
@@ -126,6 +126,11 @@ test('passes if first method in class and opening brace before it', (t: AssertCo
   t.is(results.errorCount, 0);
 });
 
+test('passes if first method in class and opening brace before it and generic closing greater-than same line', (t: AssertContext) => {
+  const results = TestHelpers.lint('passes/closingGenericSameLineAsOpenBrace.ts');
+  t.is(results.errorCount, 0);
+});
+
 test('passes if new line and method comment between class methods', (t: AssertContext) => {
   const results = TestHelpers.lint('passes/newLineAndMethodComment.ts');
   t.is(results.errorCount, 0);

--- a/src/linesBetweenClassMembersRule.spec.ts
+++ b/src/linesBetweenClassMembersRule.spec.ts
@@ -131,6 +131,11 @@ test('passes if first method in class and opening brace before it and generic cl
   t.is(results.errorCount, 0);
 });
 
+test('passes if implements keyword is on a line after class definition', (t: AssertContext) => {
+  const results = TestHelpers.lint('passes/implementsKeywordOnLineBelowClassDefinition.ts');
+  t.is(results.errorCount, 0);
+});
+
 test('passes if new line and method comment between class methods', (t: AssertContext) => {
   const results = TestHelpers.lint('passes/newLineAndMethodComment.ts');
   t.is(results.errorCount, 0);

--- a/src/linesBetweenClassMembersRule.ts
+++ b/src/linesBetweenClassMembersRule.ts
@@ -105,8 +105,8 @@ class LinesBetweenClassMembersWalker extends Lint.RuleWalker {
    * We do not want to enforce a newline after opening brace for the class declaration
    */
   private isPrevLineOpeningBrace(node: ts.FunctionLikeDeclaration, sourceFile: ts.SourceFile): boolean {
-    const prevLine = this.getPrevLinesText(node, sourceFile);
-    return prevLine.trim() === '{';
+    var prevLine = this.getPrevLinesText(node, sourceFile).trim();
+    return prevLine === '{' || prevLine === '> {';
   }
 
   /**

--- a/src/linesBetweenClassMembersRule.ts
+++ b/src/linesBetweenClassMembersRule.ts
@@ -97,7 +97,7 @@ class LinesBetweenClassMembersWalker extends Lint.RuleWalker {
    */
   private isPreviousLineClassDec(node: ts.FunctionLikeDeclaration, sourceFile: ts.SourceFile): boolean {
     const prevLine = this.getPrevLinesText(node, sourceFile);
-    return /\bclass\b\s+[A-Za-z0-9]+/.test(prevLine);
+    return /\bclass\b\s+[A-Za-z0-9]+/.test(prevLine) || prevLine.trim().startsWith('implements');
   }
 
   /**

--- a/src/linesBetweenClassMembersRule.ts
+++ b/src/linesBetweenClassMembersRule.ts
@@ -105,7 +105,7 @@ class LinesBetweenClassMembersWalker extends Lint.RuleWalker {
    * We do not want to enforce a newline after opening brace for the class declaration
    */
   private isPrevLineOpeningBrace(node: ts.FunctionLikeDeclaration, sourceFile: ts.SourceFile): boolean {
-    var prevLine = this.getPrevLinesText(node, sourceFile).trim();
+    const prevLine = this.getPrevLinesText(node, sourceFile).trim();
     return prevLine === '{' || prevLine === '> {';
   }
 

--- a/test/fixtures/passes/closingGenericSameLineAsOpenBrace.ts
+++ b/test/fixtures/passes/closingGenericSameLineAsOpenBrace.ts
@@ -1,0 +1,13 @@
+export class ClosingGenericSameLineAsOpenBrace<
+  TSomeType, 
+  TSomeOtherType, 
+  TThirdType
+> {
+    someType: TSomeType;
+    someOtherType: TSomeOtherType;
+    thirdType: TThirdType;
+
+    constructor() {
+
+    }
+}

--- a/test/fixtures/passes/closingGenericSameLineAsOpenBrace.ts
+++ b/test/fixtures/passes/closingGenericSameLineAsOpenBrace.ts
@@ -3,11 +3,11 @@ export class ClosingGenericSameLineAsOpenBrace<
   TSomeOtherType, 
   TThirdType
 > {
-    someType: TSomeType;
-    someOtherType: TSomeOtherType;
-    thirdType: TThirdType;
-
     constructor() {
 
     }
+
+    someType: TSomeType;
+    someOtherType: TSomeOtherType;
+    thirdType: TThirdType;
 }

--- a/test/fixtures/passes/implementsKeywordOnLineBelowClassDefinition.ts
+++ b/test/fixtures/passes/implementsKeywordOnLineBelowClassDefinition.ts
@@ -1,0 +1,10 @@
+interface SomeInterface {
+    name: string;
+}
+
+export class SomeClass
+  implements SomeInterface {
+  constructor() { }
+
+  name = 'test';
+}


### PR DESCRIPTION
Fixes #13 

I couldn't get `npm run lint` to pass - it keeps checking `node_modules`, I think the command options might be wrong?

Also most of the `fix` tests failed for me even though I didn't change anything that should effect them.