### PR TITLE
Handle class declaration being split over multiple lines

### DIFF
--- a/linesBetweenClassMembersRule.js
+++ b/linesBetweenClassMembersRule.js
@@ -101,7 +101,7 @@ var LinesBetweenClassMembersWalker = (function (_super) {
      */
     LinesBetweenClassMembersWalker.prototype.isPreviousLineClassDec = function (node, sourceFile) {
         var prevLine = this.getPrevLinesText(node, sourceFile);
-        return /\bclass\b\s+[A-Za-z0-9]+/.test(prevLine);
+        return /\b(class|implements|extends)\b\s+[A-Za-z0-9]+/.test(prevLine);
     };
     /**
      * Tests whether the previous line is the opening brace

--- a/src/linesBetweenClassMembersRule.spec.ts
+++ b/src/linesBetweenClassMembersRule.spec.ts
@@ -231,3 +231,8 @@ test('ignores exported object with multiple methods', (t: AssertContext) => {
   const results = TestHelpers.lint('passes/exportMultipleMethods.ts');
   t.is(results.errorCount, 0);
 });
+
+test('passes when class dec is split over several lines', (t: AssertContext) => {
+  const results = TestHelpers.lint('passes/multilineClassDec.ts');
+  t.is(results.errorCount, 0);
+});

--- a/src/linesBetweenClassMembersRule.ts
+++ b/src/linesBetweenClassMembersRule.ts
@@ -97,7 +97,7 @@ class LinesBetweenClassMembersWalker extends Lint.RuleWalker {
    */
   private isPreviousLineClassDec(node: ts.FunctionLikeDeclaration, sourceFile: ts.SourceFile): boolean {
     const prevLine = this.getPrevLinesText(node, sourceFile);
-    return /\bclass\b\s+[A-Za-z0-9]+/.test(prevLine);
+    return /\b(class|implements|extends)\b\s+[A-Za-z0-9]+/.test(prevLine);
   }
 
   /**

--- a/test/fixtures/passes/multilineClassDec.ts
+++ b/test/fixtures/passes/multilineClassDec.ts
@@ -1,0 +1,7 @@
+class BaseClass {
+}
+
+export class ExtremelyOverlongClassNameCausingLineBreak
+  implements BaseClass {
+  constructor() {}
+}


### PR DESCRIPTION
Fixes #19 